### PR TITLE
Updates standard build script to deploy to webOS or re-deploy to LuneOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,29 @@ The application state is an alpha state with some unfinished tasks. It contains 
 It is tested physically only on HP Pre3, where is implemented also a compass feature.
 You can search places, get directions, use street view, launch Navit from popup menu etc. Check also the settings and more maptypes.
 
+
+## Desktop Development
+In a web browser, open debug.html.  
+
+To test the minified version  
+`tools/deploy.sh`  
+then open deploy/index.html
+
+
+## Building, Installation, & Debugging
+
+### webOS
+`tools/deploy.sh -w`  
+
+### LuneOS first installation
+`tools/deploy.sh -w`
+`adb push org.webosports.app.maps_0.0.1_all.ipk /media/internal`  
+`adb shell`  
+`luna-send -n 6 luna://com.palm.appinstaller/install '{"subscribe":true, "target": "/media/internal/org.webosports.app.maps_0.0.1_all.ipk"}'`  
+
+### LuneOS re-install
+`tools/deploy.sh -i`  
  
+### LuneOS Debugging 
+`adb forward tcp:1122 tcp:1122`  
+In Safari, navigate to http://localhost:1122


### PR DESCRIPTION
This will help new developers get going with Maps - tools/deploy.sh is the standard script to run for Enyo 2 apps.

Aside from putting the minified app in deploy, rather than deploy/org.webosports.app.maps, it is functionally equivalent to `node enyo/tools/deploy.js -v -o deploy/org.webosports.app.maps`

Open-WebOS-DCO-1.0-Signed-Off-By: Doug Reeder reeder.29@gmail.com
