### PR TITLE
Fix issue with not loading on LuneOS

### DIFF
--- a/source/views/main.js
+++ b/source/views/main.js
@@ -162,7 +162,7 @@ create: function(){
 	this.haveCompass = false;
 	this.compassOpacity = 0;
 	/* Adaptation to Firefox/FirefoxOS */
-	this.transform = enyo.platform.platformName.contains("firefox") ? "" : "-webkit-";
+	this.transform = (enyo.platform.firefoxOS || enyo.platform.platformName === "firefox") ? "" : "-webkit-";
 	//this.transform = "-webkit-";
 	this.trackPosition = false;
 	


### PR DESCRIPTION
The .contains("firefox") didn't work for some reason. Based on EnyoJS documentation the above 2 enyo.platform evaluations should cover both FirefoxOS and Firefox browser :)
