### PR TITLE
Temporary fix for LuneOS detection

### DIFF
--- a/enyo/source/dom/platform.js
+++ b/enyo/source/dom/platform.js
@@ -70,6 +70,8 @@
 		{platform: 'webos', regex: /(?:web|hpw)OS\/(\d+)/},
 		// webOS 4 / OpenWebOS
 		{platform: "webos", regex: /WebAppManager|Isis|webOS\./, forceVersion: 4},
+		// Open webOS release LuneOS
+		{platform: 'webos', regex: /LuneOS/, forceVersion: 4, extra: {luneos: 1}},
 		// desktop Safari
 		{platform: 'safari', regex: /Version\/(\d+)[.\d]+\s+Safari/},
 		// desktop Chrome


### PR DESCRIPTION
This is addressed in future Enyo (2.6?) release, however not yet working in the current release, so manually adding the LuneOS detection for now. This way the webOSGeolocation will be used instead of the W3CGeolocation.
