### PR TITLE
Make it work for gh-pages on desktop browsers and Browser app

### DIFF
--- a/source/loader.js
+++ b/source/loader.js
@@ -57,7 +57,8 @@ if (cookie) {
 function loadScript() {
   var script = document.createElement('script');
   script.type = 'text/javascript';
-  script.src = "http://maps.google.com/maps/api/js" + gAPI + "&libraries=places,geometry&language=" + Prefs.lang + '&callback=initialize';
+  //script.src = "http://maps.google.com/maps/api/js" + gAPI + "&libraries=places,geometry&language=" + Prefs.lang + '&callback=initialize';
+   script.src = "https://maps.googleapis.com/maps/api/js" + gAPI + "&libraries=places,geometry&language=" + Prefs.lang + '&callback=initialize';
   document.body.appendChild(script);
 }
 

--- a/source/views/main.js
+++ b/source/views/main.js
@@ -198,8 +198,15 @@ cleanup: function () {
 	this.savePrefs();
 	
 	if(enyo.platform.webos) {
-		this.$.webOSCompass.stopTracking();
-		this.$.webOSAccel.stop();
+		try
+		{
+			this.$.webOSCompass.stopTracking();
+			this.$.webOSAccel.stop();
+		}
+		catch(err)
+		{
+			console.log("Error in WebOSCompass and/or WebOSAccel (probably because we're on Desktop): "+ err.message);	
+		}
 	};
 	
 	enyo.log("*** EXIT ***");
@@ -211,10 +218,17 @@ init: function(){
 	this.$.layout.rendered();
 	
 	if(enyo.platform.webos) {
+	try
+	{
 		window.PalmSystem.stageReady();
 		window.PalmSystem.setWindowOrientation("free");
 		/* Workaround the pixelRatio, because of Pre3 */
 		window.devicePixelRatio = window.innerWidth/this.$.mainPane.node.offsetWidth;	
+	}
+	catch (err)
+	{
+		console.log("Error in window.PalmSystem (probably because we're on Desktop): "+ err.message);
+	}
 	};
 
 	this.$.pullout.$.APIver.setContent("<span style='color: gray; font-size: 12px'>Google Maps API: v" + google.maps.version + "</span>");
@@ -241,19 +255,37 @@ initAfterIdle: function() {
 	/**  This function is called on first map idle  **/
 
 	if(enyo.platform.webos) {
+	try
+	{
 		window.PalmSystem.stageReady();
 		window.PalmSystem.setWindowOrientation("free");
+	}
+	catch(err)
+	{
+		console.log("Error in window.PalmSystem (probably because we're on Desktop): "+ err.message);
+	}
+	finally
+	{
 		this.compassContainer = document.createElement("div");
 		this.compassContainer.id = 'compass';
 		this.needleContainer = document.createElement("div");
 		this.needleContainer.id = 'needle';
-		this.$.webOSCompass.startTracking();
-		this.$.webOSAccel.start();
-		//this.$.webOSCompass.getCurrentHeading();
-		this.checkNavit(); 
+		try
+		{
+			this.$.webOSCompass.startTracking();
+			this.$.webOSAccel.start();
+			this.$.webOSCompass.getCurrentHeading();
+		}
+		catch(err)
+		{
+			console.log("Error in WebOSCompass and/or WebOSAccel (probably because we're on Desktop): "+ err.message);	
+		}
+		finally
+		{
+			this.checkNavit(); 
+		}
+	}
 	};
-	
-	
 	
 	/* DELETE !!!! */
 	//this.statusPanel(window.devicePixelRatio, 5);


### PR DESCRIPTION
-Made the API file via HTTPS because gh-pages is served via https and modern browsers don't like to load the API via HTTP
-Added the webOS specific calls (PalmSystem, webos-lib, enyo-webos) inside try-catch-finally so the org.webosports.app.browser can run the Maps app with QtCreator as well :)
