### PR TITLE
Unify layout

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -6,9 +6,13 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf8"/>
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 	<meta name="viewport" content="initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, width=device-width, height=device-height" />	
-	<script src="enyo/enyo.js" charset="utf-8"></script>
-	<script src="source/loader.js" charset="utf-8"></script>
-	<script src="source/package.js" charset="utf-8"></script>
+		<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+		<script src="enyo/tools/less.js"></script>
+		<!-- enyo (debug) -->
+		<script src="enyo/enyo.js"></script>
+		<!-- application (debug) -->
+		<script src="source/loader.js" charset="utf-8"></script>
+		<script src="source/package.js" charset="utf-8"></script>
 </head>	
 <body class="enyo-unselectable">		
 </body>

--- a/source/package.js
+++ b/source/package.js
@@ -1,7 +1,7 @@
 enyo.depends(
 	"OsmMap.js",
 	"$lib/layout",
-	"$lib/onyx",
+	"$lib/onyx/source",
 	"$lib/enyo-ilib",
 	"$lib/webos-lib",
 	"style",

--- a/source/style/Theme.less
+++ b/source/style/Theme.less
@@ -1,0 +1,28 @@
+/* 
+    You can modify the Onyx theme by adding variable and rule overrides to this
+    file.  To enable theming, follow these steps:
+
+    1. In debug.html, uncomment the line referencing "less-<version number>.min.js".
+    2. In package.js, change "$lib/onyx" to "$lib/onyx/source".
+    3. Also in package.js, add "Theme.less" (this file).
+    4. Add variable and rule overrides below.
+
+    See [https://github.com/enyojs/enyo/wiki/UI-Theming] for more information.
+*/
+
+
+/* Onyx default variable definitions: */
+@import "../../lib/onyx/css/onyx-variables.less";
+
+/* Place your Onyx variable overrides here -------------------- */
+
+@onyx-togglebutton-background: #82bef1;
+
+/* ------------------------------------- end variable overrides */
+
+/* Onyx rule definitions: */
+@import "../../lib/onyx/css/onyx-rules.less";
+
+/* Place your Onyx rule overrides here ------------------------ */
+
+/* ----------------------------------------- end rule overrides */

--- a/source/style/package.js
+++ b/source/style/package.js
@@ -1,4 +1,5 @@
 enyo.depends(
 	"maps.css",
-	"details.css"
+	"details.css",
+	"Theme.less"
 );


### PR DESCRIPTION
Legacy Enyo 1.0 and QML apps use a blue background for toggle button, so
we want to use the same in Enyo 2.0 apps for consistency.

Signed-off-by: Herman van Hazendonk github.com@herrie.org
