### PR TITLE
org.webosports.app.maps: Add requiredPermissions

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -9,5 +9,6 @@
 	"icon": "icon.png",
 	"splashicon": "icon-256x256.png",
 	"uiRevision": "2",
-	"keywords": [ "Maps", "Navigator", "route", "gps", "google" ]
+	"keywords": [ "Maps", "Navigator", "route", "gps", "google" ],
+	"requiredPermissions": [ "system", "networking.internal", "services" ]
 }


### PR DESCRIPTION
Solves:
May 28 18:01:20 qemux86-64 user.warn ls-hubd: [] [pmlog] ls-hubd LSHUB_NO_ROLE_FILE {"APP_ID":"org.webosports.app.maps"} No role file for application id: "org.webosports.app.maps"

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>